### PR TITLE
[Travis CI] set digest algorithm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 before_install:
-  - echo "personal-digest-preferences SHA512 SHA256 SHA384 SHA224" >> ~/.gnupg/gpg.conf
+  - echo "digest-algo sha256" >> ~/.gnupg/gpg.conf
   - openssl aes-256-cbc -K $encrypted_4d9724976ba6_key -iv $encrypted_4d9724976ba6_iv
     -in key.gpg.enc -out key.gpg -d
   - gpg --import key.gpg


### PR DESCRIPTION
The fix was found [here](https://askubuntu.com/questions/819641/reprepro-signature-by-key-uses-weak-digest-algorithm-sha1).

I'm not sure why #22 didn't work. It worked well on CentOS.